### PR TITLE
Add tools for checking dead links

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,15 @@
+name: Check Markdown links
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - master
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+docker run -v ${PWD}:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md


### PR DESCRIPTION
This commit adds 2 things - `check.sh` and GitHub Action, aiming to close #2 .

+ `check.sh` should be run manually by developers after changing content
+ GitHub Action will run:
  + every night
  + when pushing new commit

In addition to that, there is a problem：What should we do when finding dead links? Delete them or fix them?

